### PR TITLE
Fix: detailView가 두 번 호출되는 이슈 해결

### DIFF
--- a/Expo1900/Expo1900/CatalogView/CatalogViewController.swift
+++ b/Expo1900/Expo1900/CatalogView/CatalogViewController.swift
@@ -16,9 +16,11 @@ class CatalogViewController: UIViewController, UITableViewDataSource, UITableVie
   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
     if segue.identifier == "detailView" {
       let detailvc = segue.destination as? DetailViewController
-      
-      if let index = sender as? Int {
-        let exhibitionWorkCatalog = viewModel.exhibitionWorkInfo(at: index)
+
+      if let cell = sender as? CatalogCell {
+        // FIXME: - table view 클릭한 cell의 index를 가져오는 방법 변경 요망
+        let cellIndex = Int(cell.frame.minY)/200
+        let exhibitionWorkCatalog = viewModel.exhibitionWorkInfo(at: cellIndex)
         detailvc?.viewModel.update(model: exhibitionWorkCatalog)
       }
     }
@@ -40,10 +42,5 @@ class CatalogViewController: UIViewController, UITableViewDataSource, UITableVie
     catalogCell.update(info: exhibitionWorkInfo)
     
     return catalogCell
-  }
-  
-  func tableView(_ tableView: UITableView,
-                 didSelectRowAt indexPath: IndexPath) {
-    performSegue(withIdentifier: CatalogViewController.segueIdentifier, sender: indexPath.row)
   }
 }


### PR DESCRIPTION
- performSegue() 삭제
- cellIndex 생성 및 해당 index에 맞게 호출

- Issue
1. cellIndex의 불안한 호출 해결 필요
  - CatalogViewController.swift Line: 22
  - let cellIndex = Int(cell.frame.minY)/200